### PR TITLE
Cache SEL and Class pointers

### DIFF
--- a/main.c
+++ b/main.c
@@ -66,9 +66,9 @@ uint32_t windowCount = 0;
 //@end
 NSUInteger applicationShouldTerminate(id self, SEL _sel, id sender)
 {
-	printf("requested to terminate\n");
-	terminated = true;
-	return 0;
+    printf("requested to terminate\n");
+    terminated = true;
+    return 0;
 }
 
 //@interface WindowDelegate : NSObject<NSWindowDelegate>
@@ -85,449 +85,487 @@ NSUInteger applicationShouldTerminate(id self, SEL _sel, id sender)
 //@end
 void windowWillClose(id self, SEL _sel, id notification)
 {
-	printf("window will close\n");
-	assert(windowCount);
-	if(--windowCount == 0)
-		terminated = true;
+    printf("window will close\n");
+    assert(windowCount);
+    if(--windowCount == 0)
+        terminated = true;
 }
 
 int main()
 {
     SEL allocSel = sel_registerName("alloc");
     SEL initSel = sel_registerName("init");
-    SEL autoreleaseSel = sel_registerName("autorelease");
-    Class NSStringClass = objc_getClass("NSString");
-    SEL stringWithUTF8StringSel = sel_registerName("stringWithUTF8String:");
-    SEL setDelegateSel = sel_registerName("setDelegate:");
-    SEL addItemSel = sel_registerName("addItem:");
 
-	#ifdef ARC_AVAILABLE
-	@autoreleasepool
-	{
-	#else
-	//NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-	//would be nice to use objc_autoreleasePoolPush instead, but it's not publically available in the headers
-	id poolAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSAutoreleasePool"), allocSel);
-	id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, initSel);
-	#endif
-	
-	//[NSApplication sharedApplication];
-	((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
-	
-	//[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-	((void (*)(id, SEL, NSInteger))objc_msgSend)(NSApp, sel_registerName("setActivationPolicy:"), 0);
-	
-	//AppDelegate * dg = [[AppDelegate alloc] init];
-	Class appDelegateClass = objc_allocateClassPair((Class)objc_getClass("NSObject"), "AppDelegate", 0);
-	bool resultAddProtoc = class_addProtocol(appDelegateClass, objc_getProtocol("NSApplicationDelegate"));
-	assert(resultAddProtoc);
-	bool resultAddMethod = class_addMethod(appDelegateClass, sel_registerName("applicationShouldTerminate:"), (IMP)applicationShouldTerminate, NSUIntegerEncoding "@:@");
-	assert(resultAddMethod);
-	id dgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)appDelegateClass, allocSel);
-	id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, initSel);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(dg, autoreleaseSel);
-	#endif
-	
-	//[NSApp setDelegate:dg];
-	((void (*)(id, SEL, id))objc_msgSend)(NSApp, setDelegateSel, dg);
-	
-	// only needed if we don't use [NSApp run]
-	//[NSApp finishLaunching];
-	((void (*)(id, SEL))objc_msgSend)(NSApp, sel_registerName("finishLaunching"));
-	
-	//id menubar = [[NSMenu alloc] init];
-	id menubarAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), allocSel);
-	id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, initSel);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(menubar, autoreleaseSel);
-	#endif
+#ifdef ARC_AVAILABLE
+    @autoreleasepool
+    {
+#else
+        //NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+        //would be nice to use objc_autoreleasePoolPush instead, but it's not publically available in the headers
+        Class NSAutoreleasePoolClass = objc_getClass("NSAutoreleasePool");
+        id poolAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSAutoreleasePoolClass, allocSel);
+        id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, initSel);
+#endif
 
-	//id appMenuItem = [[NSMenuItem alloc] init];
-	id appMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), allocSel);
-	id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, initSel);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(appMenuItem, autoreleaseSel);
-	#endif
+        //[NSApplication sharedApplication];
+        Class NSApplicationClass = objc_getClass("NSApplication");
+        SEL sharedApplicationSel = sel_registerName("sharedApplication");
+        ((id (*)(Class, SEL))objc_msgSend)(NSApplicationClass, sharedApplicationSel);
 
-	//[menubar addItem:appMenuItem];
-	((void (*)(id, SEL, id))objc_msgSend)(menubar, addItemSel, appMenuItem);
-	
-	//[NSApp setMainMenu:menubar];
-	((id (*)(id, SEL, id))objc_msgSend)(NSApp, sel_registerName("setMainMenu:"), menubar);
-	
-	//id appMenu = [[NSMenu alloc] init];
-	id appMenuAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), allocSel);
-	id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, initSel);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(appMenu, autoreleaseSel);
-	#endif
-	
-	//id appName = [[NSProcessInfo processInfo] processName];
-	id processInfo = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSProcessInfo"), sel_registerName("processInfo"));
-	id appName = ((id (*)(id, SEL))objc_msgSend)(processInfo, sel_registerName("processName"));
-	
-	//id quitTitle = [@"Quit " stringByAppendingString:appName];
-	id quitTitlePrefixString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "Quit ");
-	id quitTitle = ((id (*)(id, SEL, id))objc_msgSend)(quitTitlePrefixString, sel_registerName("stringByAppendingString:"), appName);
-	
-	//id quitMenuItem = [[NSMenuItem alloc] initWithTitle:quitTitle action:@selector(terminate:) keyEquivalent:@"q"];
-	id quitMenuItemKey = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "q");
-	id quitMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), allocSel);
-	id quitMenuItem = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(quitMenuItemAlloc, sel_registerName("initWithTitle:action:keyEquivalent:"), quitTitle, sel_registerName("terminate:"), quitMenuItemKey);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(quitMenuItem, autoreleaseSel);
-	#endif
+        //[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        SEL setActivationPolicySel = sel_registerName("setActivationPolicy:");
+        ((void (*)(id, SEL, NSInteger))objc_msgSend)(NSApp, setActivationPolicySel, 0);
 
-	//[appMenu addItem:quitMenuItem];
-	((void (*)(id, SEL, id))objc_msgSend)(appMenu, addItemSel, quitMenuItem);
-	
-	//[appMenuItem setSubmenu:appMenu];
-	((void (*)(id, SEL, id))objc_msgSend)(appMenuItem, sel_registerName("setSubmenu:"), appMenu);
-	
-	//id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 500) styleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:NO];
-	NSRect rect = {{0, 0}, {500, 500}};
-	id windowAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSWindow"), allocSel);
-	id window = ((id (*)(id, SEL, NSRect, NSUInteger, NSUInteger, BOOL))objc_msgSend)(windowAlloc, sel_registerName("initWithContentRect:styleMask:backing:defer:"), rect, 15, 2, NO);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(window, autoreleaseSel);
-	#endif
-	
-	// when we are not using ARC, than window will be added to autorelease pool
-	// so if we close it by hand (pressing red button), we don't want it to be released for us
-	// so it will be released by autorelease pool later
-	//[window setReleasedWhenClosed:NO];
-	((void (*)(id, SEL, BOOL))objc_msgSend)(window, sel_registerName("setReleasedWhenClosed:"), NO);
+        //AppDelegate * dg = [[AppDelegate alloc] init];
+        Class NSObjectClass = objc_getClass("NSObject");
+        Class AppDelegateClass = objc_allocateClassPair(NSObjectClass, "AppDelegate", 0);
+        Protocol* NSApplicationDelegateProtocol = objc_getProtocol("NSApplicationDelegate");
+        bool resultAddProtoc = class_addProtocol(AppDelegateClass, NSApplicationDelegateProtocol);
+        assert(resultAddProtoc);
+        SEL applicationShouldTerminateSel = sel_registerName("applicationShouldTerminate:");
+        bool resultAddMethod = class_addMethod(AppDelegateClass, applicationShouldTerminateSel, (IMP)applicationShouldTerminate, NSUIntegerEncoding "@:@");
+        assert(resultAddMethod);
+        id dgAlloc = ((id (*)(Class, SEL))objc_msgSend)(AppDelegateClass, allocSel);
+        id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, initSel);
 
-	windowCount = 1;
-	
-	//WindowDelegate * wdg = [[WindowDelegate alloc] init];
-	Class WindowDelegateClass = objc_allocateClassPair((Class)objc_getClass("NSObject"), "WindowDelegate", 0);
-	resultAddProtoc = class_addProtocol(WindowDelegateClass, objc_getProtocol("NSWindowDelegate"));
-	assert(resultAddProtoc);
-	resultAddMethod = class_addMethod(WindowDelegateClass, sel_registerName("windowWillClose:"), (IMP)windowWillClose,  "v@:@");
-	assert(resultAddMethod);
-	id wdgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)WindowDelegateClass, allocSel);
-	id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, initSel);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(wdg, autoreleaseSel);
-	#endif
+        SEL autoreleaseSel = sel_registerName("autorelease");
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(dg, autoreleaseSel);
+#endif
 
-	//[window setDelegate:wdg];
-	((void (*)(id, SEL, id))objc_msgSend)(window, setDelegateSel, wdg);
-	
-	//NSView * contentView = [window contentView];
-	id contentView = ((id (*)(id, SEL))objc_msgSend)(window, sel_registerName("contentView"));
+        //[NSApp setDelegate:dg];
+        SEL setDelegateSel = sel_registerName("setDelegate:");
+        ((void (*)(id, SEL, id))objc_msgSend)(NSApp, setDelegateSel, dg);
 
-	// disable this if you don't want retina support
-	//[contentView setWantsBestResolutionOpenGLSurface:YES];
-	((void (*)(id, SEL, BOOL))objc_msgSend)(contentView, sel_registerName("setWantsBestResolutionOpenGLSurface:"), YES);
-	
-	//[window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
-	NSPoint point = {20, 20};
-	((void (*)(id, SEL, NSPoint))objc_msgSend)(window, sel_registerName("cascadeTopLeftFromPoint:"), point);
-	
-	//[window setTitle:@"sup"];
-	id titleString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "sup from C");
-	((void (*)(id, SEL, id))objc_msgSend)(window, sel_registerName("setTitle:"), titleString);
-	
-	//NSOpenGLPixelFormatAttribute glAttributes[] =
-	//{
-	//	NSOpenGLPFAColorSize, 24,
-	//	NSOpenGLPFAAlphaSize, 8,
-	//	NSOpenGLPFADoubleBuffer,
-	//	NSOpenGLPFAAccelerated,
-	//	NSOpenGLPFANoRecovery,
-	//	NSOpenGLPFASampleBuffers, 1,
-	//	NSOpenGLPFASamples, 4,
-	//	NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy, // or NSOpenGLProfileVersion3_2Core
-	//	0
-	//};
-	uint32_t glAttributes[] =
-	{
-		8, 24,
-		11, 8,
-		5,
-		73,
-		72,
-		55, 1,
-		56, 4,
-		99, 0x1000, // or 0x3200
-		0
-	};
-	
-	//NSOpenGLPixelFormat * pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:glAttributes];
-	id pixelFormatAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLPixelFormat"), allocSel);
-	id pixelFormat = ((id (*)(id, SEL, const uint32_t*))objc_msgSend)(pixelFormatAlloc, sel_registerName("initWithAttributes:"), glAttributes);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(pixelFormat, autoreleaseSel);
-	#endif
+        // only needed if we don't use [NSApp run]
+        //[NSApp finishLaunching];
+        SEL finishLaunchingSel = sel_registerName("finishLaunching");
+        ((void (*)(id, SEL))objc_msgSend)(NSApp, finishLaunchingSel);
 
-	//NSOpenGLContext * openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
-	id openGLContextAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLContext"), allocSel);
-	id openGLContext = ((id (*)(id, SEL, id, id))objc_msgSend)(openGLContextAlloc, sel_registerName("initWithFormat:shareContext:"), pixelFormat, nil);
-	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(openGLContext, autoreleaseSel);
-	#endif
-	
-	//[openGLContext setView:contentView];
-	((void (*)(id, SEL, id))objc_msgSend)(openGLContext, sel_registerName("setView:"), contentView);
-	
-	//[window makeKeyAndOrderFront:window];
-	((void (*)(id, SEL, id))objc_msgSend)(window, sel_registerName("makeKeyAndOrderFront:"), window);
-	
-	//[window setAcceptsMouseMovedEvents:YES];
-	((void (*)(id, SEL, BOOL))objc_msgSend)(window, sel_registerName("setAcceptsMouseMovedEvents:"), YES);
-	
-	//[window setBackgroundColor:[NSColor blackColor]];
-	id blackColor = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSColor"), sel_registerName("blackColor"));
-	((void (*)(id, SEL, id))objc_msgSend)(window, sel_registerName("setBackgroundColor:"), blackColor);
-	
-	// TODO do we really need this?
-	//[NSApp activateIgnoringOtherApps:YES];
-	((void (*)(id, SEL, BOOL))objc_msgSend)(NSApp, sel_registerName("activateIgnoringOtherApps:"), YES);
-	
-	// explicit runloop
-	printf("entering runloop\n");
-	while(!terminated)
-	{
-		//NSEvent * event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
-		static Class NSDateClass = objc_getClass("NSDate");
-		static SEL distantPastSel = sel_registerName("distantPast");
-		id distantPast = ((id (*)(id, SEL))objc_msgSend)((id)NSDateClass, distantPastSel);
-		
-		static SEL nextEventMatchingMaskSel = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
-		id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, nextEventMatchingMaskSel, NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
-		
-		static SEL frameSel = sel_registerName("frame");
-		
-		if(event)
-		{
-			//NSEventType eventType = [event type];
-			static SEL typeSel = sel_registerName("type");
-			NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, typeSel);
-			
-			static SEL buttonNumberSel = sel_registerName("buttonNumber");
-			static SEL keyCodeSel = sel_registerName("keyCode");
-			
-			switch(eventType)
-			{
-			//case NSMouseMoved:
-			//case NSLeftMouseDragged:
-			//case NSRightMouseDragged:
-			//case NSOtherMouseDragged:
-			case 5:
-			case 6:
-			case 7:
-			case 27:
-			{
-				//NSWindow * currentWindow = [NSApp keyWindow];
-				static SEL keyWindowSel = sel_registerName("keyWindow");
-				id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, keyWindowSel);
+        //id menubar = [[NSMenu alloc] init];
+        Class NSMenuClass = objc_getClass("NSMenu");
+        id menubarAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
+        id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, initSel);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(menubar, autoreleaseSel);
+#endif
 
-				//NSRect adjustFrame = [[currentWindow contentView] frame];
-				static SEL contentViewSel = sel_registerName("contentView");
-				id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, contentViewSel);
-				NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, frameSel);
-				
-				//NSPoint p = [currentWindow mouseLocationOutsideOfEventStream];
-				// NSPoint is small enough to fit a register, so no need for objc_msgSend_stret
-				static SEL mouseLocationOutsideOfEventStreamSel = sel_registerName("mouseLocationOutsideOfEventStream");
-				NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, mouseLocationOutsideOfEventStreamSel);
-				
-				// map input to content view rect
-				if(p.x < 0) p.x = 0;
-				else if(p.x > adjustFrame.size.width) p.x = adjustFrame.size.width;
-				if(p.y < 0) p.y = 0;
-				else if(p.y > adjustFrame.size.height) p.y = adjustFrame.size.height;
+        //id appMenuItem = [[NSMenuItem alloc] init];
+        Class NSMenuItemClass = objc_getClass("NSMenuItem");
+        id appMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
+        id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, initSel);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(appMenuItem, autoreleaseSel);
+#endif
 
-				// map input to pixels
-				NSRect r = {p.x, p.y, 0, 0};
-				//r = [currentWindowContentView convertRectToBacking:r];
-				static SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
-				r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, convertRectToBackingSel, r);
-				p = r.origin;
-				
-				printf("mouse moved to %f %f\n", p.x, p.y);
-				break;
-			}
-			//case NSLeftMouseDown:
-			case 1:
-				printf("mouse left key down\n");
-				break;
-			//case NSLeftMouseUp:
-			case 2:
-				printf("mouse left key up\n");
-				break;
-			//case NSRightMouseDown:
-			case 3:
-				printf("mouse right key down\n");
-				break;
-			//case NSRightMouseUp:
-			case 4:
-				printf("mouse right key up\n");
-				break;
-			//case NSOtherMouseDown:
-			case 25:
-			{
-				// number == 2 is a middle button
+        //[menubar addItem:appMenuItem];
+        SEL addItemSel = sel_registerName("addItem:");
+        ((void (*)(id, SEL, id))objc_msgSend)(menubar, addItemSel, appMenuItem);
 
-				//NSInteger number = [event buttonNumber];
-				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
-				printf("mouse other key down : %i\n", (int)number);
-				break;
-			}
-			//case NSOtherMouseUp:
-			case 26:
-			{
-				//NSInteger number = [event buttonNumber];
-				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
-				printf("mouse other key up : %i\n", (int)number);
-				break;
-			}
-			//case NSScrollWheel:
-			case 22:
-			{
-				//CGFloat deltaX = [event scrollingDeltaX];
-				static SEL scrollingDeltaXSel = sel_registerName("scrollingDeltaX");
-				CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaXSel);
+        //[NSApp setMainMenu:menubar];
+        SEL setMainMenuSel = sel_registerName("setMainMenu:");
+        ((id (*)(id, SEL, id))objc_msgSend)(NSApp, setMainMenuSel, menubar);
 
-				//CGFloat deltaY = [event scrollingDeltaY];
-				static SEL scrollingDeltaYSel = sel_registerName("scrollingDeltaY");
-				CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaYSel);
-				
-				//BOOL precisionScrolling = [event hasPreciseScrollingDeltas];
-				static SEL hasPreciseScrollingDeltasSel = sel_registerName("hasPreciseScrollingDeltas");
-				BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, hasPreciseScrollingDeltasSel);
+        //id appMenu = [[NSMenu alloc] init];
+        id appMenuAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
+        id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, initSel);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(appMenu, autoreleaseSel);
+#endif
 
-				if(precisionScrolling)
-				{
-					deltaX *= 0.1f; // similar to glfw
-					deltaY *= 0.1f;
-				}
+        //id appName = [[NSProcessInfo processInfo] processName];
+        Class NSProcessInfoClass = objc_getClass("NSProcessInfo");
+        SEL processInfoSel = sel_registerName("processInfo");
+        id processInfo = ((id (*)(Class, SEL))objc_msgSend)(NSProcessInfoClass, processInfoSel);
+        SEL processNameSel = sel_registerName("processName");
+        id appName = ((id (*)(id, SEL))objc_msgSend)(processInfo, processNameSel);
 
-				if(fabs(deltaX) > 0.0f || fabs(deltaY) > 0.0f)
-					printf("mouse scroll wheel delta %f %f\n", deltaX, deltaY);
-				break;
-			}
-			//case NSFlagsChanged:
-			case 12:
-			{
-				//NSEventModifierFlags modifiers = [event modifierFlags];
-				static SEL modifierFlagsSel = sel_registerName("modifierFlags");
-				NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, modifierFlagsSel);
-				
-				// based on NSEventModifierFlags
-				struct
-				{
-					union
-					{
-						struct
-						{
-							uint8_t alpha_shift:1;
-							uint8_t shift:1;
-							uint8_t control:1;
-							uint8_t alternate:1;
-							uint8_t command:1;
-							uint8_t numeric_pad:1;
-							uint8_t help:1;
-							uint8_t function:1;
-						};
-						uint8_t mask;
-					};
-				} keys;
-				
-				//keys.mask = (modifiers & NSDeviceIndependentModifierFlagsMask) >> 16;
-				keys.mask = (modifiers & 0xffff0000UL) >> 16;
-				
-				printf("mod keys : mask %03u state %u%u%u%u%u%u%u%u\n", keys.mask, keys.alpha_shift, keys.shift, keys.control, keys.alternate, keys.command, keys.numeric_pad, keys.help, keys.function);
-				break;
-			}
-			//case NSKeyDown:
-			case 10:
-			{
-				//NSString * inputText = [event characters];
-				static SEL charactersSel = sel_registerName("characters");
-				id inputText = ((id (*)(id, SEL))objc_msgSend)(event, charactersSel);
-				
-				//const char * inputTextUTF8 = [inputText UTF8String];
-				static SEL UTF8StringSel = sel_registerName("UTF8String");
-				const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, UTF8StringSel);
-				
-				//you can get list of virtual key codes from Carbon HIToolbox/Events.h
-				//uint16_t keyCode = [event keyCode];
-				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
+        //id quitTitle = [@"Quit " stringByAppendingString:appName];
+        Class NSStringClass = objc_getClass("NSString");
+        SEL stringWithUTF8StringSel = sel_registerName("stringWithUTF8String:");
+        id quitTitlePrefixString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "Quit ");
+        SEL stringByAppendingStringSel = sel_registerName("stringByAppendingString:");
+        id quitTitle = ((id (*)(id, SEL, id))objc_msgSend)(quitTitlePrefixString, stringByAppendingStringSel, appName);
 
-				printf("key down %u, text '%s'\n", keyCode, inputTextUTF8);
-				break;
-			}
-			//case NSKeyUp:
-			case 11:
-			{
-				//uint16_t keyCode = [event keyCode];
-				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
-				
-				printf("key up %u\n", keyCode);
-				break;
-			}
-			default:
-				break;
-			}
-			
-			//[NSApp sendEvent:event];
-			static SEL sendEventSel = sel_registerName("sendEvent");
-			((void (*)(id, SEL, id))objc_msgSend)(NSApp, sendEventSel, event);
-			
-			// if user closes the window we might need to terminate asap
-			if(terminated)
-				break;
-			
-			//[NSApp updateWindows];
-			static SEL updateWindowsSel = sel_registerName("updateWindows");
-			((void (*)(id, SEL))objc_msgSend)(NSApp, updateWindowsSel);
-		}
-		
-		// do runloop stuff
-		//[openGLContext update]; // probably we only need to do it when we resize the window
-		static SEL updateSel = sel_registerName("update");
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, updateSel);
-		
-		//[openGLContext makeCurrentContext];
-		static SEL makeCurrentContextSel = sel_registerName("makeCurrentContext");
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, makeCurrentContextSel);
-		
-		//NSRect rect = [contentView frame];
-		NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, frameSel);
-		
-		//rect = [contentView convertRectToBacking:rect];
-		static SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
-		rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, convertRectToBackingSel, rect);
-		
-		glViewport(0, 0, rect.size.width, rect.size.height);
-		
-		glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-		glClear(GL_COLOR_BUFFER_BIT);
-		glColor3f(1.0f, 0.85f, 0.35f);
-		glBegin(GL_TRIANGLES);
-		{
-			glVertex3f(  0.0,  0.6, 0.0);
-			glVertex3f( -0.2, -0.3, 0.0);
-			glVertex3f(  0.2, -0.3 ,0.0);
-		}
-		glEnd();
-		
-		//[openGLContext flushBuffer];
-		static SEL flushBufferSel = sel_registerName("flushBuffer");
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, flushBufferSel);
-	}
-		
-	printf("gracefully terminated\n");
-	
-	#ifdef ARC_AVAILABLE
-	}
-	#else
-	//[pool drain];
-	((void (*)(id, SEL))objc_msgSend)(pool, sel_registerName("drain"));
-	#endif
-	return 0;
+        //id quitMenuItem = [[NSMenuItem alloc] initWithTitle:quitTitle action:@selector(terminate:) keyEquivalent:@"q"];
+        id quitMenuItemKey = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "q");
+        id quitMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
+        SEL initWithTitleSel = sel_registerName("initWithTitle:action:keyEquivalent:");
+        SEL terminateSel = sel_registerName("terminate:");
+        id quitMenuItem = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(quitMenuItemAlloc, initWithTitleSel, quitTitle, terminateSel, quitMenuItemKey);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(quitMenuItem, autoreleaseSel);
+#endif
+
+        //[appMenu addItem:quitMenuItem];
+        ((void (*)(id, SEL, id))objc_msgSend)(appMenu, addItemSel, quitMenuItem);
+
+        //[appMenuItem setSubmenu:appMenu];
+        SEL setSubmenuSel = sel_registerName("setSubmenu:");
+        ((void (*)(id, SEL, id))objc_msgSend)(appMenuItem, setSubmenuSel, appMenu);
+
+        //id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 500) styleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:NO];
+        NSRect rect = {{0, 0}, {500, 500}};
+        Class NSWindowClass = objc_getClass("NSWindow");
+        id windowAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSWindowClass, allocSel);
+        SEL initWithContentRectSel = sel_registerName("initWithContentRect:styleMask:backing:defer:");
+        id window = ((id (*)(id, SEL, NSRect, NSUInteger, NSUInteger, BOOL))objc_msgSend)(windowAlloc, initWithContentRectSel, rect, 15, 2, NO);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(window, autoreleaseSel);
+#endif
+
+        // when we are not using ARC, than window will be added to autorelease pool
+        // so if we close it by hand (pressing red button), we don't want it to be released for us
+        // so it will be released by autorelease pool later
+        //[window setReleasedWhenClosed:NO];
+        SEL setReleasedWhenClosedSel = sel_registerName("setReleasedWhenClosed:");
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(window, setReleasedWhenClosedSel, NO);
+
+        windowCount = 1;
+
+        //WindowDelegate * wdg = [[WindowDelegate alloc] init];
+        Class WindowDelegateClass = objc_allocateClassPair(NSObjectClass, "WindowDelegate", 0);
+        Protocol* NSWindowDelegateProtocol = objc_getProtocol("NSWindowDelegate");
+        resultAddProtoc = class_addProtocol(WindowDelegateClass, NSWindowDelegateProtocol);
+        assert(resultAddProtoc);
+        SEL windowWillCloseSel = sel_registerName("windowWillClose:");
+        resultAddMethod = class_addMethod(WindowDelegateClass, windowWillCloseSel, (IMP)windowWillClose,  "v@:@");
+        assert(resultAddMethod);
+        id wdgAlloc = ((id (*)(Class, SEL))objc_msgSend)(WindowDelegateClass, allocSel);
+        id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, initSel);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(wdg, autoreleaseSel);
+#endif
+
+        //[window setDelegate:wdg];
+        ((void (*)(id, SEL, id))objc_msgSend)(window, setDelegateSel, wdg);
+
+        //NSView * contentView = [window contentView];
+        SEL contentViewSel = sel_registerName("contentView");
+        id contentView = ((id (*)(id, SEL))objc_msgSend)(window, contentViewSel);
+
+        // disable this if you don't want retina support
+        //[contentView setWantsBestResolutionOpenGLSurface:YES];
+        SEL setWantsBestResolutionOpenGLSurfaceSel = sel_registerName("setWantsBestResolutionOpenGLSurface:");
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(contentView, setWantsBestResolutionOpenGLSurfaceSel, YES);
+
+        //[window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
+        NSPoint point = {20, 20};
+        SEL cascadeTopLeftFromPointSel = sel_registerName("cascadeTopLeftFromPoint:");
+        ((void (*)(id, SEL, NSPoint))objc_msgSend)(window, cascadeTopLeftFromPointSel, point);
+
+        //[window setTitle:@"sup"];
+        id titleString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "sup from C");
+        SEL setTitleSel = sel_registerName("setTitle:");
+        ((void (*)(id, SEL, id))objc_msgSend)(window, setTitleSel, titleString);
+
+        //NSOpenGLPixelFormatAttribute glAttributes[] =
+        //{
+        //	NSOpenGLPFAColorSize, 24,
+        //	NSOpenGLPFAAlphaSize, 8,
+        //	NSOpenGLPFADoubleBuffer,
+        //	NSOpenGLPFAAccelerated,
+        //	NSOpenGLPFANoRecovery,
+        //	NSOpenGLPFASampleBuffers, 1,
+        //	NSOpenGLPFASamples, 4,
+        //	NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy, // or NSOpenGLProfileVersion3_2Core
+        //	0
+        //};
+        uint32_t glAttributes[] =
+        {
+            8, 24,
+            11, 8,
+            5,
+            73,
+            72,
+            55, 1,
+            56, 4,
+            99, 0x1000, // or 0x3200
+            0
+        };
+
+        //NSOpenGLPixelFormat * pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:glAttributes];
+        Class NSOpenGLPixelFormatClass = objc_getClass("NSOpenGLPixelFormat");
+        id pixelFormatAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLPixelFormatClass, allocSel);
+        SEL initWithAttributesSel = sel_registerName("initWithAttributes:");
+        id pixelFormat = ((id (*)(id, SEL, const uint32_t*))objc_msgSend)(pixelFormatAlloc, initWithAttributesSel, glAttributes);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(pixelFormat, autoreleaseSel);
+#endif
+
+        //NSOpenGLContext * openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
+        Class NSOpenGLContextClass = objc_getClass("NSOpenGLContext");
+        id openGLContextAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLContextClass, allocSel);
+        SEL initWithFormatSel = sel_registerName("initWithFormat:shareContext:");
+        id openGLContext = ((id (*)(id, SEL, id, id))objc_msgSend)(openGLContextAlloc, initWithFormatSel, pixelFormat, nil);
+#ifndef ARC_AVAILABLE
+        ((void (*)(id, SEL))objc_msgSend)(openGLContext, autoreleaseSel);
+#endif
+
+        //[openGLContext setView:contentView];
+        SEL setViewSel = sel_registerName("setView:");
+        ((void (*)(id, SEL, id))objc_msgSend)(openGLContext, setViewSel, contentView);
+
+        //[window makeKeyAndOrderFront:window];
+        SEL makeKeyAndOrderFrontSel = sel_registerName("makeKeyAndOrderFront:");
+        ((void (*)(id, SEL, id))objc_msgSend)(window, makeKeyAndOrderFrontSel, window);
+
+        //[window setAcceptsMouseMovedEvents:YES];
+        SEL setAcceptsMouseMovedEventsSel = sel_registerName("setAcceptsMouseMovedEvents:");
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(window, setAcceptsMouseMovedEventsSel, YES);
+
+        //[window setBackgroundColor:[NSColor blackColor]];
+        Class NSColorClass = objc_getClass("NSColor");
+        id blackColor = ((id (*)(Class, SEL))objc_msgSend)(NSColorClass, sel_registerName("blackColor"));
+        SEL setBackgroundColorSel = sel_registerName("setBackgroundColor:");
+        ((void (*)(id, SEL, id))objc_msgSend)(window, setBackgroundColorSel, blackColor);
+
+        // TODO do we really need this?
+        //[NSApp activateIgnoringOtherApps:YES];
+        SEL activateIgnoringOtherAppsSel = sel_registerName("activateIgnoringOtherApps:");
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(NSApp, activateIgnoringOtherAppsSel, YES);
+
+        // explicit runloop
+        printf("entering runloop\n");
+
+        Class NSDateClass = objc_getClass("NSDate");
+        SEL distantPastSel = sel_registerName("distantPast");
+        SEL nextEventMatchingMaskSel = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
+        SEL frameSel = sel_registerName("frame");
+        SEL typeSel = sel_registerName("type");
+        SEL buttonNumberSel = sel_registerName("buttonNumber");
+        SEL keyCodeSel = sel_registerName("keyCode");
+        SEL keyWindowSel = sel_registerName("keyWindow");
+        SEL mouseLocationOutsideOfEventStreamSel = sel_registerName("mouseLocationOutsideOfEventStream");
+        SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
+        SEL scrollingDeltaXSel = sel_registerName("scrollingDeltaX");
+        SEL scrollingDeltaYSel = sel_registerName("scrollingDeltaY");
+        SEL hasPreciseScrollingDeltasSel = sel_registerName("hasPreciseScrollingDeltas");
+        SEL modifierFlagsSel = sel_registerName("modifierFlags");
+        SEL charactersSel = sel_registerName("characters");
+        SEL UTF8StringSel = sel_registerName("UTF8String");
+        SEL sendEventSel = sel_registerName("sendEvent:");
+        SEL updateWindowsSel = sel_registerName("updateWindows");
+        SEL updateSel = sel_registerName("update");
+        SEL makeCurrentContextSel = sel_registerName("makeCurrentContext");
+        SEL flushBufferSel = sel_registerName("flushBuffer");
+
+        while(!terminated)
+        {
+            //NSEvent * event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
+
+            id distantPast = ((id (*)(Class, SEL))objc_msgSend)(NSDateClass, distantPastSel);
+
+
+            id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, nextEventMatchingMaskSel, NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
+
+            if(event)
+            {
+                //NSEventType eventType = [event type];
+                NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, typeSel);
+
+                switch(eventType)
+                {
+                        //case NSMouseMoved:
+                        //case NSLeftMouseDragged:
+                        //case NSRightMouseDragged:
+                        //case NSOtherMouseDragged:
+                    case 5:
+                    case 6:
+                    case 7:
+                    case 27:
+                    {
+                        //NSWindow * currentWindow = [NSApp keyWindow];
+                        id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, keyWindowSel);
+
+                        //NSRect adjustFrame = [[currentWindow contentView] frame];
+                        id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, contentViewSel);
+                        NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, frameSel);
+
+                        //NSPoint p = [currentWindow mouseLocationOutsideOfEventStream];
+                        // NSPoint is small enough to fit a register, so no need for objc_msgSend_stret
+                        NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, mouseLocationOutsideOfEventStreamSel);
+
+                        // map input to content view rect
+                        if(p.x < 0) p.x = 0;
+                        else if(p.x > adjustFrame.size.width) p.x = adjustFrame.size.width;
+                        if(p.y < 0) p.y = 0;
+                        else if(p.y > adjustFrame.size.height) p.y = adjustFrame.size.height;
+
+                        // map input to pixels
+                        NSRect r = {p.x, p.y, 0, 0};
+                        //r = [currentWindowContentView convertRectToBacking:r];
+                        r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, convertRectToBackingSel, r);
+                        p = r.origin;
+
+                        printf("mouse moved to %f %f\n", p.x, p.y);
+                        break;
+                    }
+                        //case NSLeftMouseDown:
+                    case 1:
+                        printf("mouse left key down\n");
+                        break;
+                        //case NSLeftMouseUp:
+                    case 2:
+                        printf("mouse left key up\n");
+                        break;
+                        //case NSRightMouseDown:
+                    case 3:
+                        printf("mouse right key down\n");
+                        break;
+                        //case NSRightMouseUp:
+                    case 4:
+                        printf("mouse right key up\n");
+                        break;
+                        //case NSOtherMouseDown:
+                    case 25:
+                    {
+                        // number == 2 is a middle button
+
+                        //NSInteger number = [event buttonNumber];
+                        NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
+                        printf("mouse other key down : %i\n", (int)number);
+                        break;
+                    }
+                        //case NSOtherMouseUp:
+                    case 26:
+                    {
+                        //NSInteger number = [event buttonNumber];
+                        NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
+                        printf("mouse other key up : %i\n", (int)number);
+                        break;
+                    }
+                        //case NSScrollWheel:
+                    case 22:
+                    {
+                        //CGFloat deltaX = [event scrollingDeltaX];
+                        CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaXSel);
+
+                        //CGFloat deltaY = [event scrollingDeltaY];
+                        CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaYSel);
+
+                        //BOOL precisionScrolling = [event hasPreciseScrollingDeltas];
+                        BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, hasPreciseScrollingDeltasSel);
+
+                        if(precisionScrolling)
+                        {
+                            deltaX *= 0.1f; // similar to glfw
+                            deltaY *= 0.1f;
+                        }
+
+                        if(fabs(deltaX) > 0.0f || fabs(deltaY) > 0.0f)
+                            printf("mouse scroll wheel delta %f %f\n", deltaX, deltaY);
+                        break;
+                    }
+                        //case NSFlagsChanged:
+                    case 12:
+                    {
+                        //NSEventModifierFlags modifiers = [event modifierFlags];
+                        NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, modifierFlagsSel);
+
+                        // based on NSEventModifierFlags
+                        struct
+                        {
+                            union
+                            {
+                                struct
+                                {
+                                    uint8_t alpha_shift:1;
+                                    uint8_t shift:1;
+                                    uint8_t control:1;
+                                    uint8_t alternate:1;
+                                    uint8_t command:1;
+                                    uint8_t numeric_pad:1;
+                                    uint8_t help:1;
+                                    uint8_t function:1;
+                                };
+                                uint8_t mask;
+                            };
+                        } keys;
+                        
+                        //keys.mask = (modifiers & NSDeviceIndependentModifierFlagsMask) >> 16;
+                        keys.mask = (modifiers & 0xffff0000UL) >> 16;
+                        
+                        printf("mod keys : mask %03u state %u%u%u%u%u%u%u%u\n", keys.mask, keys.alpha_shift, keys.shift, keys.control, keys.alternate, keys.command, keys.numeric_pad, keys.help, keys.function);
+                        break;
+                    }
+                        //case NSKeyDown:
+                    case 10:
+                    {
+                        //NSString * inputText = [event characters];
+                        id inputText = ((id (*)(id, SEL))objc_msgSend)(event, charactersSel);
+                        
+                        //const char * inputTextUTF8 = [inputText UTF8String];
+                        const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, UTF8StringSel);
+                        
+                        //you can get list of virtual key codes from Carbon HIToolbox/Events.h
+                        //uint16_t keyCode = [event keyCode];
+                        uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
+                        
+                        printf("key down %u, text '%s'\n", keyCode, inputTextUTF8);
+                        break;
+                    }
+                        //case NSKeyUp:
+                    case 11:
+                    {
+                        //uint16_t keyCode = [event keyCode];
+                        uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
+                        
+                        printf("key up %u\n", keyCode);
+                        break;
+                    }
+                    default:
+                        break;
+                }
+                
+                //[NSApp sendEvent:event];
+                ((void (*)(id, SEL, id))objc_msgSend)(NSApp, sendEventSel, event);
+                
+                // if user closes the window we might need to terminate asap
+                if(terminated)
+                    break;
+                
+                //[NSApp updateWindows];
+                ((void (*)(id, SEL))objc_msgSend)(NSApp, updateWindowsSel);
+            }
+            
+            // do runloop stuff
+            //[openGLContext update]; // probably we only need to do it when we resize the window
+            ((void (*)(id, SEL))objc_msgSend)(openGLContext, updateSel);
+            
+            //[openGLContext makeCurrentContext];
+            ((void (*)(id, SEL))objc_msgSend)(openGLContext, makeCurrentContextSel);
+            
+            //NSRect rect = [contentView frame];
+            NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, frameSel);
+            
+            //rect = [contentView convertRectToBacking:rect];
+            rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, convertRectToBackingSel, rect);
+            
+            glViewport(0, 0, rect.size.width, rect.size.height);
+            
+            glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glColor3f(1.0f, 0.85f, 0.35f);
+            glBegin(GL_TRIANGLES);
+            {
+                glVertex3f(  0.0f,  0.6f, 0.0f);
+                glVertex3f( -0.2f, -0.3f, 0.0f);
+                glVertex3f(  0.2f, -0.3f ,0.0f);
+            }
+            glEnd();
+            
+            //[openGLContext flushBuffer];
+            ((void (*)(id, SEL))objc_msgSend)(openGLContext, flushBufferSel);
+        }
+        
+        printf("gracefully terminated\n");
+        
+#ifdef ARC_AVAILABLE
+    }
+#else
+    //[pool drain];
+    ((void (*)(id, SEL))objc_msgSend)(pool, sel_registerName("drain"));
+#endif
+    return 0;
 }

--- a/main.c
+++ b/main.c
@@ -66,9 +66,9 @@ uint32_t windowCount = 0;
 //@end
 NSUInteger applicationShouldTerminate(id self, SEL _sel, id sender)
 {
-    printf("requested to terminate\n");
-    terminated = true;
-    return 0;
+	printf("requested to terminate\n");
+	terminated = true;
+	return 0;
 }
 
 //@interface WindowDelegate : NSObject<NSWindowDelegate>
@@ -85,487 +85,487 @@ NSUInteger applicationShouldTerminate(id self, SEL _sel, id sender)
 //@end
 void windowWillClose(id self, SEL _sel, id notification)
 {
-    printf("window will close\n");
-    assert(windowCount);
-    if(--windowCount == 0)
-        terminated = true;
+	printf("window will close\n");
+	assert(windowCount);
+	if(--windowCount == 0)
+		terminated = true;
 }
 
 int main()
 {
-    SEL allocSel = sel_registerName("alloc");
-    SEL initSel = sel_registerName("init");
+	SEL allocSel = sel_registerName("alloc");
+	SEL initSel = sel_registerName("init");
 
 #ifdef ARC_AVAILABLE
-    @autoreleasepool
-    {
+	@autoreleasepool
+	{
 #else
-        //NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-        //would be nice to use objc_autoreleasePoolPush instead, but it's not publically available in the headers
-        Class NSAutoreleasePoolClass = objc_getClass("NSAutoreleasePool");
-        id poolAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSAutoreleasePoolClass, allocSel);
-        id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, initSel);
+		//NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+		//would be nice to use objc_autoreleasePoolPush instead, but it's not publically available in the headers
+		Class NSAutoreleasePoolClass = objc_getClass("NSAutoreleasePool");
+		id poolAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSAutoreleasePoolClass, allocSel);
+		id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, initSel);
 #endif
 
-        //[NSApplication sharedApplication];
-        Class NSApplicationClass = objc_getClass("NSApplication");
-        SEL sharedApplicationSel = sel_registerName("sharedApplication");
-        ((id (*)(Class, SEL))objc_msgSend)(NSApplicationClass, sharedApplicationSel);
+		//[NSApplication sharedApplication];
+		Class NSApplicationClass = objc_getClass("NSApplication");
+		SEL sharedApplicationSel = sel_registerName("sharedApplication");
+		((id (*)(Class, SEL))objc_msgSend)(NSApplicationClass, sharedApplicationSel);
 
-        //[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-        SEL setActivationPolicySel = sel_registerName("setActivationPolicy:");
-        ((void (*)(id, SEL, NSInteger))objc_msgSend)(NSApp, setActivationPolicySel, 0);
+		//[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+		SEL setActivationPolicySel = sel_registerName("setActivationPolicy:");
+		((void (*)(id, SEL, NSInteger))objc_msgSend)(NSApp, setActivationPolicySel, 0);
 
-        //AppDelegate * dg = [[AppDelegate alloc] init];
-        Class NSObjectClass = objc_getClass("NSObject");
-        Class AppDelegateClass = objc_allocateClassPair(NSObjectClass, "AppDelegate", 0);
-        Protocol* NSApplicationDelegateProtocol = objc_getProtocol("NSApplicationDelegate");
-        bool resultAddProtoc = class_addProtocol(AppDelegateClass, NSApplicationDelegateProtocol);
-        assert(resultAddProtoc);
-        SEL applicationShouldTerminateSel = sel_registerName("applicationShouldTerminate:");
-        bool resultAddMethod = class_addMethod(AppDelegateClass, applicationShouldTerminateSel, (IMP)applicationShouldTerminate, NSUIntegerEncoding "@:@");
-        assert(resultAddMethod);
-        id dgAlloc = ((id (*)(Class, SEL))objc_msgSend)(AppDelegateClass, allocSel);
-        id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, initSel);
+		//AppDelegate * dg = [[AppDelegate alloc] init];
+		Class NSObjectClass = objc_getClass("NSObject");
+		Class AppDelegateClass = objc_allocateClassPair(NSObjectClass, "AppDelegate", 0);
+		Protocol* NSApplicationDelegateProtocol = objc_getProtocol("NSApplicationDelegate");
+		bool resultAddProtoc = class_addProtocol(AppDelegateClass, NSApplicationDelegateProtocol);
+		assert(resultAddProtoc);
+		SEL applicationShouldTerminateSel = sel_registerName("applicationShouldTerminate:");
+		bool resultAddMethod = class_addMethod(AppDelegateClass, applicationShouldTerminateSel, (IMP)applicationShouldTerminate, NSUIntegerEncoding "@:@");
+		assert(resultAddMethod);
+		id dgAlloc = ((id (*)(Class, SEL))objc_msgSend)(AppDelegateClass, allocSel);
+		id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, initSel);
 
-        SEL autoreleaseSel = sel_registerName("autorelease");
+		SEL autoreleaseSel = sel_registerName("autorelease");
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(dg, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(dg, autoreleaseSel);
 #endif
 
-        //[NSApp setDelegate:dg];
-        SEL setDelegateSel = sel_registerName("setDelegate:");
-        ((void (*)(id, SEL, id))objc_msgSend)(NSApp, setDelegateSel, dg);
+		//[NSApp setDelegate:dg];
+		SEL setDelegateSel = sel_registerName("setDelegate:");
+		((void (*)(id, SEL, id))objc_msgSend)(NSApp, setDelegateSel, dg);
 
-        // only needed if we don't use [NSApp run]
-        //[NSApp finishLaunching];
-        SEL finishLaunchingSel = sel_registerName("finishLaunching");
-        ((void (*)(id, SEL))objc_msgSend)(NSApp, finishLaunchingSel);
+		// only needed if we don't use [NSApp run]
+		//[NSApp finishLaunching];
+		SEL finishLaunchingSel = sel_registerName("finishLaunching");
+		((void (*)(id, SEL))objc_msgSend)(NSApp, finishLaunchingSel);
 
-        //id menubar = [[NSMenu alloc] init];
-        Class NSMenuClass = objc_getClass("NSMenu");
-        id menubarAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
-        id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, initSel);
+		//id menubar = [[NSMenu alloc] init];
+		Class NSMenuClass = objc_getClass("NSMenu");
+		id menubarAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
+		id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, initSel);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(menubar, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(menubar, autoreleaseSel);
 #endif
 
-        //id appMenuItem = [[NSMenuItem alloc] init];
-        Class NSMenuItemClass = objc_getClass("NSMenuItem");
-        id appMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
-        id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, initSel);
+		//id appMenuItem = [[NSMenuItem alloc] init];
+		Class NSMenuItemClass = objc_getClass("NSMenuItem");
+		id appMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
+		id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, initSel);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(appMenuItem, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(appMenuItem, autoreleaseSel);
 #endif
 
-        //[menubar addItem:appMenuItem];
-        SEL addItemSel = sel_registerName("addItem:");
-        ((void (*)(id, SEL, id))objc_msgSend)(menubar, addItemSel, appMenuItem);
+		//[menubar addItem:appMenuItem];
+		SEL addItemSel = sel_registerName("addItem:");
+		((void (*)(id, SEL, id))objc_msgSend)(menubar, addItemSel, appMenuItem);
 
-        //[NSApp setMainMenu:menubar];
-        SEL setMainMenuSel = sel_registerName("setMainMenu:");
-        ((id (*)(id, SEL, id))objc_msgSend)(NSApp, setMainMenuSel, menubar);
+		//[NSApp setMainMenu:menubar];
+		SEL setMainMenuSel = sel_registerName("setMainMenu:");
+		((id (*)(id, SEL, id))objc_msgSend)(NSApp, setMainMenuSel, menubar);
 
-        //id appMenu = [[NSMenu alloc] init];
-        id appMenuAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
-        id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, initSel);
+		//id appMenu = [[NSMenu alloc] init];
+		id appMenuAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuClass, allocSel);
+		id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, initSel);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(appMenu, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(appMenu, autoreleaseSel);
 #endif
 
-        //id appName = [[NSProcessInfo processInfo] processName];
-        Class NSProcessInfoClass = objc_getClass("NSProcessInfo");
-        SEL processInfoSel = sel_registerName("processInfo");
-        id processInfo = ((id (*)(Class, SEL))objc_msgSend)(NSProcessInfoClass, processInfoSel);
-        SEL processNameSel = sel_registerName("processName");
-        id appName = ((id (*)(id, SEL))objc_msgSend)(processInfo, processNameSel);
+		//id appName = [[NSProcessInfo processInfo] processName];
+		Class NSProcessInfoClass = objc_getClass("NSProcessInfo");
+		SEL processInfoSel = sel_registerName("processInfo");
+		id processInfo = ((id (*)(Class, SEL))objc_msgSend)(NSProcessInfoClass, processInfoSel);
+		SEL processNameSel = sel_registerName("processName");
+		id appName = ((id (*)(id, SEL))objc_msgSend)(processInfo, processNameSel);
 
-        //id quitTitle = [@"Quit " stringByAppendingString:appName];
-        Class NSStringClass = objc_getClass("NSString");
-        SEL stringWithUTF8StringSel = sel_registerName("stringWithUTF8String:");
-        id quitTitlePrefixString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "Quit ");
-        SEL stringByAppendingStringSel = sel_registerName("stringByAppendingString:");
-        id quitTitle = ((id (*)(id, SEL, id))objc_msgSend)(quitTitlePrefixString, stringByAppendingStringSel, appName);
+		//id quitTitle = [@"Quit " stringByAppendingString:appName];
+		Class NSStringClass = objc_getClass("NSString");
+		SEL stringWithUTF8StringSel = sel_registerName("stringWithUTF8String:");
+		id quitTitlePrefixString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "Quit ");
+		SEL stringByAppendingStringSel = sel_registerName("stringByAppendingString:");
+		id quitTitle = ((id (*)(id, SEL, id))objc_msgSend)(quitTitlePrefixString, stringByAppendingStringSel, appName);
 
-        //id quitMenuItem = [[NSMenuItem alloc] initWithTitle:quitTitle action:@selector(terminate:) keyEquivalent:@"q"];
-        id quitMenuItemKey = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "q");
-        id quitMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
-        SEL initWithTitleSel = sel_registerName("initWithTitle:action:keyEquivalent:");
-        SEL terminateSel = sel_registerName("terminate:");
-        id quitMenuItem = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(quitMenuItemAlloc, initWithTitleSel, quitTitle, terminateSel, quitMenuItemKey);
+		//id quitMenuItem = [[NSMenuItem alloc] initWithTitle:quitTitle action:@selector(terminate:) keyEquivalent:@"q"];
+		id quitMenuItemKey = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "q");
+		id quitMenuItemAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSMenuItemClass, allocSel);
+		SEL initWithTitleSel = sel_registerName("initWithTitle:action:keyEquivalent:");
+		SEL terminateSel = sel_registerName("terminate:");
+		id quitMenuItem = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(quitMenuItemAlloc, initWithTitleSel, quitTitle, terminateSel, quitMenuItemKey);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(quitMenuItem, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(quitMenuItem, autoreleaseSel);
 #endif
 
-        //[appMenu addItem:quitMenuItem];
-        ((void (*)(id, SEL, id))objc_msgSend)(appMenu, addItemSel, quitMenuItem);
+		//[appMenu addItem:quitMenuItem];
+		((void (*)(id, SEL, id))objc_msgSend)(appMenu, addItemSel, quitMenuItem);
 
-        //[appMenuItem setSubmenu:appMenu];
-        SEL setSubmenuSel = sel_registerName("setSubmenu:");
-        ((void (*)(id, SEL, id))objc_msgSend)(appMenuItem, setSubmenuSel, appMenu);
+		//[appMenuItem setSubmenu:appMenu];
+		SEL setSubmenuSel = sel_registerName("setSubmenu:");
+		((void (*)(id, SEL, id))objc_msgSend)(appMenuItem, setSubmenuSel, appMenu);
 
-        //id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 500) styleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:NO];
-        NSRect rect = {{0, 0}, {500, 500}};
-        Class NSWindowClass = objc_getClass("NSWindow");
-        id windowAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSWindowClass, allocSel);
-        SEL initWithContentRectSel = sel_registerName("initWithContentRect:styleMask:backing:defer:");
-        id window = ((id (*)(id, SEL, NSRect, NSUInteger, NSUInteger, BOOL))objc_msgSend)(windowAlloc, initWithContentRectSel, rect, 15, 2, NO);
+		//id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 500) styleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:NO];
+		NSRect rect = {{0, 0}, {500, 500}};
+		Class NSWindowClass = objc_getClass("NSWindow");
+		id windowAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSWindowClass, allocSel);
+		SEL initWithContentRectSel = sel_registerName("initWithContentRect:styleMask:backing:defer:");
+		id window = ((id (*)(id, SEL, NSRect, NSUInteger, NSUInteger, BOOL))objc_msgSend)(windowAlloc, initWithContentRectSel, rect, 15, 2, NO);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(window, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(window, autoreleaseSel);
 #endif
 
-        // when we are not using ARC, than window will be added to autorelease pool
-        // so if we close it by hand (pressing red button), we don't want it to be released for us
-        // so it will be released by autorelease pool later
-        //[window setReleasedWhenClosed:NO];
-        SEL setReleasedWhenClosedSel = sel_registerName("setReleasedWhenClosed:");
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(window, setReleasedWhenClosedSel, NO);
+		// when we are not using ARC, than window will be added to autorelease pool
+		// so if we close it by hand (pressing red button), we don't want it to be released for us
+		// so it will be released by autorelease pool later
+		//[window setReleasedWhenClosed:NO];
+		SEL setReleasedWhenClosedSel = sel_registerName("setReleasedWhenClosed:");
+		((void (*)(id, SEL, BOOL))objc_msgSend)(window, setReleasedWhenClosedSel, NO);
 
-        windowCount = 1;
+		windowCount = 1;
 
-        //WindowDelegate * wdg = [[WindowDelegate alloc] init];
-        Class WindowDelegateClass = objc_allocateClassPair(NSObjectClass, "WindowDelegate", 0);
-        Protocol* NSWindowDelegateProtocol = objc_getProtocol("NSWindowDelegate");
-        resultAddProtoc = class_addProtocol(WindowDelegateClass, NSWindowDelegateProtocol);
-        assert(resultAddProtoc);
-        SEL windowWillCloseSel = sel_registerName("windowWillClose:");
-        resultAddMethod = class_addMethod(WindowDelegateClass, windowWillCloseSel, (IMP)windowWillClose,  "v@:@");
-        assert(resultAddMethod);
-        id wdgAlloc = ((id (*)(Class, SEL))objc_msgSend)(WindowDelegateClass, allocSel);
-        id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, initSel);
+		//WindowDelegate * wdg = [[WindowDelegate alloc] init];
+		Class WindowDelegateClass = objc_allocateClassPair(NSObjectClass, "WindowDelegate", 0);
+		Protocol* NSWindowDelegateProtocol = objc_getProtocol("NSWindowDelegate");
+		resultAddProtoc = class_addProtocol(WindowDelegateClass, NSWindowDelegateProtocol);
+		assert(resultAddProtoc);
+		SEL windowWillCloseSel = sel_registerName("windowWillClose:");
+		resultAddMethod = class_addMethod(WindowDelegateClass, windowWillCloseSel, (IMP)windowWillClose,  "v@:@");
+		assert(resultAddMethod);
+		id wdgAlloc = ((id (*)(Class, SEL))objc_msgSend)(WindowDelegateClass, allocSel);
+		id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, initSel);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(wdg, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(wdg, autoreleaseSel);
 #endif
 
-        //[window setDelegate:wdg];
-        ((void (*)(id, SEL, id))objc_msgSend)(window, setDelegateSel, wdg);
+		//[window setDelegate:wdg];
+		((void (*)(id, SEL, id))objc_msgSend)(window, setDelegateSel, wdg);
 
-        //NSView * contentView = [window contentView];
-        SEL contentViewSel = sel_registerName("contentView");
-        id contentView = ((id (*)(id, SEL))objc_msgSend)(window, contentViewSel);
+		//NSView * contentView = [window contentView];
+		SEL contentViewSel = sel_registerName("contentView");
+		id contentView = ((id (*)(id, SEL))objc_msgSend)(window, contentViewSel);
 
-        // disable this if you don't want retina support
-        //[contentView setWantsBestResolutionOpenGLSurface:YES];
-        SEL setWantsBestResolutionOpenGLSurfaceSel = sel_registerName("setWantsBestResolutionOpenGLSurface:");
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(contentView, setWantsBestResolutionOpenGLSurfaceSel, YES);
+		// disable this if you don't want retina support
+		//[contentView setWantsBestResolutionOpenGLSurface:YES];
+		SEL setWantsBestResolutionOpenGLSurfaceSel = sel_registerName("setWantsBestResolutionOpenGLSurface:");
+		((void (*)(id, SEL, BOOL))objc_msgSend)(contentView, setWantsBestResolutionOpenGLSurfaceSel, YES);
 
-        //[window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
-        NSPoint point = {20, 20};
-        SEL cascadeTopLeftFromPointSel = sel_registerName("cascadeTopLeftFromPoint:");
-        ((void (*)(id, SEL, NSPoint))objc_msgSend)(window, cascadeTopLeftFromPointSel, point);
+		//[window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
+		NSPoint point = {20, 20};
+		SEL cascadeTopLeftFromPointSel = sel_registerName("cascadeTopLeftFromPoint:");
+		((void (*)(id, SEL, NSPoint))objc_msgSend)(window, cascadeTopLeftFromPointSel, point);
 
-        //[window setTitle:@"sup"];
-        id titleString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "sup from C");
-        SEL setTitleSel = sel_registerName("setTitle:");
-        ((void (*)(id, SEL, id))objc_msgSend)(window, setTitleSel, titleString);
+		//[window setTitle:@"sup"];
+		id titleString = ((id (*)(Class, SEL, const char*))objc_msgSend)(NSStringClass, stringWithUTF8StringSel, "sup from C");
+		SEL setTitleSel = sel_registerName("setTitle:");
+		((void (*)(id, SEL, id))objc_msgSend)(window, setTitleSel, titleString);
 
-        //NSOpenGLPixelFormatAttribute glAttributes[] =
-        //{
-        //	NSOpenGLPFAColorSize, 24,
-        //	NSOpenGLPFAAlphaSize, 8,
-        //	NSOpenGLPFADoubleBuffer,
-        //	NSOpenGLPFAAccelerated,
-        //	NSOpenGLPFANoRecovery,
-        //	NSOpenGLPFASampleBuffers, 1,
-        //	NSOpenGLPFASamples, 4,
-        //	NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy, // or NSOpenGLProfileVersion3_2Core
-        //	0
-        //};
-        uint32_t glAttributes[] =
-        {
-            8, 24,
-            11, 8,
-            5,
-            73,
-            72,
-            55, 1,
-            56, 4,
-            99, 0x1000, // or 0x3200
-            0
-        };
+		//NSOpenGLPixelFormatAttribute glAttributes[] =
+		//{
+		//	NSOpenGLPFAColorSize, 24,
+		//	NSOpenGLPFAAlphaSize, 8,
+		//	NSOpenGLPFADoubleBuffer,
+		//	NSOpenGLPFAAccelerated,
+		//	NSOpenGLPFANoRecovery,
+		//	NSOpenGLPFASampleBuffers, 1,
+		//	NSOpenGLPFASamples, 4,
+		//	NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy, // or NSOpenGLProfileVersion3_2Core
+		//	0
+		//};
+		uint32_t glAttributes[] =
+		{
+			8, 24,
+			11, 8,
+			5,
+			73,
+			72,
+			55, 1,
+			56, 4,
+			99, 0x1000, // or 0x3200
+			0
+		};
 
-        //NSOpenGLPixelFormat * pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:glAttributes];
-        Class NSOpenGLPixelFormatClass = objc_getClass("NSOpenGLPixelFormat");
-        id pixelFormatAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLPixelFormatClass, allocSel);
-        SEL initWithAttributesSel = sel_registerName("initWithAttributes:");
-        id pixelFormat = ((id (*)(id, SEL, const uint32_t*))objc_msgSend)(pixelFormatAlloc, initWithAttributesSel, glAttributes);
+		//NSOpenGLPixelFormat * pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:glAttributes];
+		Class NSOpenGLPixelFormatClass = objc_getClass("NSOpenGLPixelFormat");
+		id pixelFormatAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLPixelFormatClass, allocSel);
+		SEL initWithAttributesSel = sel_registerName("initWithAttributes:");
+		id pixelFormat = ((id (*)(id, SEL, const uint32_t*))objc_msgSend)(pixelFormatAlloc, initWithAttributesSel, glAttributes);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(pixelFormat, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(pixelFormat, autoreleaseSel);
 #endif
 
-        //NSOpenGLContext * openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
-        Class NSOpenGLContextClass = objc_getClass("NSOpenGLContext");
-        id openGLContextAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLContextClass, allocSel);
-        SEL initWithFormatSel = sel_registerName("initWithFormat:shareContext:");
-        id openGLContext = ((id (*)(id, SEL, id, id))objc_msgSend)(openGLContextAlloc, initWithFormatSel, pixelFormat, nil);
+		//NSOpenGLContext * openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
+		Class NSOpenGLContextClass = objc_getClass("NSOpenGLContext");
+		id openGLContextAlloc = ((id (*)(Class, SEL))objc_msgSend)(NSOpenGLContextClass, allocSel);
+		SEL initWithFormatSel = sel_registerName("initWithFormat:shareContext:");
+		id openGLContext = ((id (*)(id, SEL, id, id))objc_msgSend)(openGLContextAlloc, initWithFormatSel, pixelFormat, nil);
 #ifndef ARC_AVAILABLE
-        ((void (*)(id, SEL))objc_msgSend)(openGLContext, autoreleaseSel);
+		((void (*)(id, SEL))objc_msgSend)(openGLContext, autoreleaseSel);
 #endif
 
-        //[openGLContext setView:contentView];
-        SEL setViewSel = sel_registerName("setView:");
-        ((void (*)(id, SEL, id))objc_msgSend)(openGLContext, setViewSel, contentView);
+		//[openGLContext setView:contentView];
+		SEL setViewSel = sel_registerName("setView:");
+		((void (*)(id, SEL, id))objc_msgSend)(openGLContext, setViewSel, contentView);
 
-        //[window makeKeyAndOrderFront:window];
-        SEL makeKeyAndOrderFrontSel = sel_registerName("makeKeyAndOrderFront:");
-        ((void (*)(id, SEL, id))objc_msgSend)(window, makeKeyAndOrderFrontSel, window);
+		//[window makeKeyAndOrderFront:window];
+		SEL makeKeyAndOrderFrontSel = sel_registerName("makeKeyAndOrderFront:");
+		((void (*)(id, SEL, id))objc_msgSend)(window, makeKeyAndOrderFrontSel, window);
 
-        //[window setAcceptsMouseMovedEvents:YES];
-        SEL setAcceptsMouseMovedEventsSel = sel_registerName("setAcceptsMouseMovedEvents:");
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(window, setAcceptsMouseMovedEventsSel, YES);
+		//[window setAcceptsMouseMovedEvents:YES];
+		SEL setAcceptsMouseMovedEventsSel = sel_registerName("setAcceptsMouseMovedEvents:");
+		((void (*)(id, SEL, BOOL))objc_msgSend)(window, setAcceptsMouseMovedEventsSel, YES);
 
-        //[window setBackgroundColor:[NSColor blackColor]];
-        Class NSColorClass = objc_getClass("NSColor");
-        id blackColor = ((id (*)(Class, SEL))objc_msgSend)(NSColorClass, sel_registerName("blackColor"));
-        SEL setBackgroundColorSel = sel_registerName("setBackgroundColor:");
-        ((void (*)(id, SEL, id))objc_msgSend)(window, setBackgroundColorSel, blackColor);
+		//[window setBackgroundColor:[NSColor blackColor]];
+		Class NSColorClass = objc_getClass("NSColor");
+		id blackColor = ((id (*)(Class, SEL))objc_msgSend)(NSColorClass, sel_registerName("blackColor"));
+		SEL setBackgroundColorSel = sel_registerName("setBackgroundColor:");
+		((void (*)(id, SEL, id))objc_msgSend)(window, setBackgroundColorSel, blackColor);
 
-        // TODO do we really need this?
-        //[NSApp activateIgnoringOtherApps:YES];
-        SEL activateIgnoringOtherAppsSel = sel_registerName("activateIgnoringOtherApps:");
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(NSApp, activateIgnoringOtherAppsSel, YES);
+		// TODO do we really need this?
+		//[NSApp activateIgnoringOtherApps:YES];
+		SEL activateIgnoringOtherAppsSel = sel_registerName("activateIgnoringOtherApps:");
+		((void (*)(id, SEL, BOOL))objc_msgSend)(NSApp, activateIgnoringOtherAppsSel, YES);
 
-        // explicit runloop
-        printf("entering runloop\n");
+		// explicit runloop
+		printf("entering runloop\n");
 
-        Class NSDateClass = objc_getClass("NSDate");
-        SEL distantPastSel = sel_registerName("distantPast");
-        SEL nextEventMatchingMaskSel = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
-        SEL frameSel = sel_registerName("frame");
-        SEL typeSel = sel_registerName("type");
-        SEL buttonNumberSel = sel_registerName("buttonNumber");
-        SEL keyCodeSel = sel_registerName("keyCode");
-        SEL keyWindowSel = sel_registerName("keyWindow");
-        SEL mouseLocationOutsideOfEventStreamSel = sel_registerName("mouseLocationOutsideOfEventStream");
-        SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
-        SEL scrollingDeltaXSel = sel_registerName("scrollingDeltaX");
-        SEL scrollingDeltaYSel = sel_registerName("scrollingDeltaY");
-        SEL hasPreciseScrollingDeltasSel = sel_registerName("hasPreciseScrollingDeltas");
-        SEL modifierFlagsSel = sel_registerName("modifierFlags");
-        SEL charactersSel = sel_registerName("characters");
-        SEL UTF8StringSel = sel_registerName("UTF8String");
-        SEL sendEventSel = sel_registerName("sendEvent:");
-        SEL updateWindowsSel = sel_registerName("updateWindows");
-        SEL updateSel = sel_registerName("update");
-        SEL makeCurrentContextSel = sel_registerName("makeCurrentContext");
-        SEL flushBufferSel = sel_registerName("flushBuffer");
+		Class NSDateClass = objc_getClass("NSDate");
+		SEL distantPastSel = sel_registerName("distantPast");
+		SEL nextEventMatchingMaskSel = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
+		SEL frameSel = sel_registerName("frame");
+		SEL typeSel = sel_registerName("type");
+		SEL buttonNumberSel = sel_registerName("buttonNumber");
+		SEL keyCodeSel = sel_registerName("keyCode");
+		SEL keyWindowSel = sel_registerName("keyWindow");
+		SEL mouseLocationOutsideOfEventStreamSel = sel_registerName("mouseLocationOutsideOfEventStream");
+		SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
+		SEL scrollingDeltaXSel = sel_registerName("scrollingDeltaX");
+		SEL scrollingDeltaYSel = sel_registerName("scrollingDeltaY");
+		SEL hasPreciseScrollingDeltasSel = sel_registerName("hasPreciseScrollingDeltas");
+		SEL modifierFlagsSel = sel_registerName("modifierFlags");
+		SEL charactersSel = sel_registerName("characters");
+		SEL UTF8StringSel = sel_registerName("UTF8String");
+		SEL sendEventSel = sel_registerName("sendEvent:");
+		SEL updateWindowsSel = sel_registerName("updateWindows");
+		SEL updateSel = sel_registerName("update");
+		SEL makeCurrentContextSel = sel_registerName("makeCurrentContext");
+		SEL flushBufferSel = sel_registerName("flushBuffer");
 
-        while(!terminated)
-        {
-            //NSEvent * event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
+		while(!terminated)
+		{
+			//NSEvent * event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
 
-            id distantPast = ((id (*)(Class, SEL))objc_msgSend)(NSDateClass, distantPastSel);
+			id distantPast = ((id (*)(Class, SEL))objc_msgSend)(NSDateClass, distantPastSel);
 
 
-            id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, nextEventMatchingMaskSel, NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
+			id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, nextEventMatchingMaskSel, NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
 
-            if(event)
-            {
-                //NSEventType eventType = [event type];
-                NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, typeSel);
+			if(event)
+			{
+				//NSEventType eventType = [event type];
+				NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, typeSel);
 
-                switch(eventType)
-                {
-                        //case NSMouseMoved:
-                        //case NSLeftMouseDragged:
-                        //case NSRightMouseDragged:
-                        //case NSOtherMouseDragged:
-                    case 5:
-                    case 6:
-                    case 7:
-                    case 27:
-                    {
-                        //NSWindow * currentWindow = [NSApp keyWindow];
-                        id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, keyWindowSel);
+				switch(eventType)
+				{
+						//case NSMouseMoved:
+						//case NSLeftMouseDragged:
+						//case NSRightMouseDragged:
+						//case NSOtherMouseDragged:
+					case 5:
+					case 6:
+					case 7:
+					case 27:
+					{
+						//NSWindow * currentWindow = [NSApp keyWindow];
+						id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, keyWindowSel);
 
-                        //NSRect adjustFrame = [[currentWindow contentView] frame];
-                        id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, contentViewSel);
-                        NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, frameSel);
+						//NSRect adjustFrame = [[currentWindow contentView] frame];
+						id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, contentViewSel);
+						NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, frameSel);
 
-                        //NSPoint p = [currentWindow mouseLocationOutsideOfEventStream];
-                        // NSPoint is small enough to fit a register, so no need for objc_msgSend_stret
-                        NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, mouseLocationOutsideOfEventStreamSel);
+						//NSPoint p = [currentWindow mouseLocationOutsideOfEventStream];
+						// NSPoint is small enough to fit a register, so no need for objc_msgSend_stret
+						NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, mouseLocationOutsideOfEventStreamSel);
 
-                        // map input to content view rect
-                        if(p.x < 0) p.x = 0;
-                        else if(p.x > adjustFrame.size.width) p.x = adjustFrame.size.width;
-                        if(p.y < 0) p.y = 0;
-                        else if(p.y > adjustFrame.size.height) p.y = adjustFrame.size.height;
+						// map input to content view rect
+						if(p.x < 0) p.x = 0;
+						else if(p.x > adjustFrame.size.width) p.x = adjustFrame.size.width;
+						if(p.y < 0) p.y = 0;
+						else if(p.y > adjustFrame.size.height) p.y = adjustFrame.size.height;
 
-                        // map input to pixels
-                        NSRect r = {p.x, p.y, 0, 0};
-                        //r = [currentWindowContentView convertRectToBacking:r];
-                        r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, convertRectToBackingSel, r);
-                        p = r.origin;
+						// map input to pixels
+						NSRect r = {p.x, p.y, 0, 0};
+						//r = [currentWindowContentView convertRectToBacking:r];
+						r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, convertRectToBackingSel, r);
+						p = r.origin;
 
-                        printf("mouse moved to %f %f\n", p.x, p.y);
-                        break;
-                    }
-                        //case NSLeftMouseDown:
-                    case 1:
-                        printf("mouse left key down\n");
-                        break;
-                        //case NSLeftMouseUp:
-                    case 2:
-                        printf("mouse left key up\n");
-                        break;
-                        //case NSRightMouseDown:
-                    case 3:
-                        printf("mouse right key down\n");
-                        break;
-                        //case NSRightMouseUp:
-                    case 4:
-                        printf("mouse right key up\n");
-                        break;
-                        //case NSOtherMouseDown:
-                    case 25:
-                    {
-                        // number == 2 is a middle button
+						printf("mouse moved to %f %f\n", p.x, p.y);
+						break;
+					}
+						//case NSLeftMouseDown:
+					case 1:
+						printf("mouse left key down\n");
+						break;
+						//case NSLeftMouseUp:
+					case 2:
+						printf("mouse left key up\n");
+						break;
+						//case NSRightMouseDown:
+					case 3:
+						printf("mouse right key down\n");
+						break;
+						//case NSRightMouseUp:
+					case 4:
+						printf("mouse right key up\n");
+						break;
+						//case NSOtherMouseDown:
+					case 25:
+					{
+						// number == 2 is a middle button
 
-                        //NSInteger number = [event buttonNumber];
-                        NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
-                        printf("mouse other key down : %i\n", (int)number);
-                        break;
-                    }
-                        //case NSOtherMouseUp:
-                    case 26:
-                    {
-                        //NSInteger number = [event buttonNumber];
-                        NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
-                        printf("mouse other key up : %i\n", (int)number);
-                        break;
-                    }
-                        //case NSScrollWheel:
-                    case 22:
-                    {
-                        //CGFloat deltaX = [event scrollingDeltaX];
-                        CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaXSel);
+						//NSInteger number = [event buttonNumber];
+						NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
+						printf("mouse other key down : %i\n", (int)number);
+						break;
+					}
+						//case NSOtherMouseUp:
+					case 26:
+					{
+						//NSInteger number = [event buttonNumber];
+						NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
+						printf("mouse other key up : %i\n", (int)number);
+						break;
+					}
+						//case NSScrollWheel:
+					case 22:
+					{
+						//CGFloat deltaX = [event scrollingDeltaX];
+						CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaXSel);
 
-                        //CGFloat deltaY = [event scrollingDeltaY];
-                        CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaYSel);
+						//CGFloat deltaY = [event scrollingDeltaY];
+						CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaYSel);
 
-                        //BOOL precisionScrolling = [event hasPreciseScrollingDeltas];
-                        BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, hasPreciseScrollingDeltasSel);
+						//BOOL precisionScrolling = [event hasPreciseScrollingDeltas];
+						BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, hasPreciseScrollingDeltasSel);
 
-                        if(precisionScrolling)
-                        {
-                            deltaX *= 0.1f; // similar to glfw
-                            deltaY *= 0.1f;
-                        }
+						if(precisionScrolling)
+						{
+							deltaX *= 0.1f; // similar to glfw
+							deltaY *= 0.1f;
+						}
 
-                        if(fabs(deltaX) > 0.0f || fabs(deltaY) > 0.0f)
-                            printf("mouse scroll wheel delta %f %f\n", deltaX, deltaY);
-                        break;
-                    }
-                        //case NSFlagsChanged:
-                    case 12:
-                    {
-                        //NSEventModifierFlags modifiers = [event modifierFlags];
-                        NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, modifierFlagsSel);
+						if(fabs(deltaX) > 0.0f || fabs(deltaY) > 0.0f)
+							printf("mouse scroll wheel delta %f %f\n", deltaX, deltaY);
+						break;
+					}
+						//case NSFlagsChanged:
+					case 12:
+					{
+						//NSEventModifierFlags modifiers = [event modifierFlags];
+						NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, modifierFlagsSel);
 
-                        // based on NSEventModifierFlags
-                        struct
-                        {
-                            union
-                            {
-                                struct
-                                {
-                                    uint8_t alpha_shift:1;
-                                    uint8_t shift:1;
-                                    uint8_t control:1;
-                                    uint8_t alternate:1;
-                                    uint8_t command:1;
-                                    uint8_t numeric_pad:1;
-                                    uint8_t help:1;
-                                    uint8_t function:1;
-                                };
-                                uint8_t mask;
-                            };
-                        } keys;
-                        
-                        //keys.mask = (modifiers & NSDeviceIndependentModifierFlagsMask) >> 16;
-                        keys.mask = (modifiers & 0xffff0000UL) >> 16;
-                        
-                        printf("mod keys : mask %03u state %u%u%u%u%u%u%u%u\n", keys.mask, keys.alpha_shift, keys.shift, keys.control, keys.alternate, keys.command, keys.numeric_pad, keys.help, keys.function);
-                        break;
-                    }
-                        //case NSKeyDown:
-                    case 10:
-                    {
-                        //NSString * inputText = [event characters];
-                        id inputText = ((id (*)(id, SEL))objc_msgSend)(event, charactersSel);
-                        
-                        //const char * inputTextUTF8 = [inputText UTF8String];
-                        const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, UTF8StringSel);
-                        
-                        //you can get list of virtual key codes from Carbon HIToolbox/Events.h
-                        //uint16_t keyCode = [event keyCode];
-                        uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
-                        
-                        printf("key down %u, text '%s'\n", keyCode, inputTextUTF8);
-                        break;
-                    }
-                        //case NSKeyUp:
-                    case 11:
-                    {
-                        //uint16_t keyCode = [event keyCode];
-                        uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
-                        
-                        printf("key up %u\n", keyCode);
-                        break;
-                    }
-                    default:
-                        break;
-                }
-                
-                //[NSApp sendEvent:event];
-                ((void (*)(id, SEL, id))objc_msgSend)(NSApp, sendEventSel, event);
-                
-                // if user closes the window we might need to terminate asap
-                if(terminated)
-                    break;
-                
-                //[NSApp updateWindows];
-                ((void (*)(id, SEL))objc_msgSend)(NSApp, updateWindowsSel);
-            }
-            
-            // do runloop stuff
-            //[openGLContext update]; // probably we only need to do it when we resize the window
-            ((void (*)(id, SEL))objc_msgSend)(openGLContext, updateSel);
-            
-            //[openGLContext makeCurrentContext];
-            ((void (*)(id, SEL))objc_msgSend)(openGLContext, makeCurrentContextSel);
-            
-            //NSRect rect = [contentView frame];
-            NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, frameSel);
-            
-            //rect = [contentView convertRectToBacking:rect];
-            rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, convertRectToBackingSel, rect);
-            
-            glViewport(0, 0, rect.size.width, rect.size.height);
-            
-            glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-            glClear(GL_COLOR_BUFFER_BIT);
-            glColor3f(1.0f, 0.85f, 0.35f);
-            glBegin(GL_TRIANGLES);
-            {
-                glVertex3f(  0.0f,  0.6f, 0.0f);
-                glVertex3f( -0.2f, -0.3f, 0.0f);
-                glVertex3f(  0.2f, -0.3f ,0.0f);
-            }
-            glEnd();
-            
-            //[openGLContext flushBuffer];
-            ((void (*)(id, SEL))objc_msgSend)(openGLContext, flushBufferSel);
-        }
-        
-        printf("gracefully terminated\n");
-        
+						// based on NSEventModifierFlags
+						struct
+						{
+							union
+							{
+								struct
+								{
+									uint8_t alpha_shift:1;
+									uint8_t shift:1;
+									uint8_t control:1;
+									uint8_t alternate:1;
+									uint8_t command:1;
+									uint8_t numeric_pad:1;
+									uint8_t help:1;
+									uint8_t function:1;
+								};
+								uint8_t mask;
+							};
+						} keys;
+						
+						//keys.mask = (modifiers & NSDeviceIndependentModifierFlagsMask) >> 16;
+						keys.mask = (modifiers & 0xffff0000UL) >> 16;
+						
+						printf("mod keys : mask %03u state %u%u%u%u%u%u%u%u\n", keys.mask, keys.alpha_shift, keys.shift, keys.control, keys.alternate, keys.command, keys.numeric_pad, keys.help, keys.function);
+						break;
+					}
+						//case NSKeyDown:
+					case 10:
+					{
+						//NSString * inputText = [event characters];
+						id inputText = ((id (*)(id, SEL))objc_msgSend)(event, charactersSel);
+						
+						//const char * inputTextUTF8 = [inputText UTF8String];
+						const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, UTF8StringSel);
+						
+						//you can get list of virtual key codes from Carbon HIToolbox/Events.h
+						//uint16_t keyCode = [event keyCode];
+						uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
+						
+						printf("key down %u, text '%s'\n", keyCode, inputTextUTF8);
+						break;
+					}
+						//case NSKeyUp:
+					case 11:
+					{
+						//uint16_t keyCode = [event keyCode];
+						uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
+						
+						printf("key up %u\n", keyCode);
+						break;
+					}
+					default:
+						break;
+				}
+				
+				//[NSApp sendEvent:event];
+				((void (*)(id, SEL, id))objc_msgSend)(NSApp, sendEventSel, event);
+				
+				// if user closes the window we might need to terminate asap
+				if(terminated)
+					break;
+				
+				//[NSApp updateWindows];
+				((void (*)(id, SEL))objc_msgSend)(NSApp, updateWindowsSel);
+			}
+			
+			// do runloop stuff
+			//[openGLContext update]; // probably we only need to do it when we resize the window
+			((void (*)(id, SEL))objc_msgSend)(openGLContext, updateSel);
+			
+			//[openGLContext makeCurrentContext];
+			((void (*)(id, SEL))objc_msgSend)(openGLContext, makeCurrentContextSel);
+			
+			//NSRect rect = [contentView frame];
+			NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, frameSel);
+			
+			//rect = [contentView convertRectToBacking:rect];
+			rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, convertRectToBackingSel, rect);
+			
+			glViewport(0, 0, rect.size.width, rect.size.height);
+			
+			glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
+			glClear(GL_COLOR_BUFFER_BIT);
+			glColor3f(1.0f, 0.85f, 0.35f);
+			glBegin(GL_TRIANGLES);
+			{
+				glVertex3f(  0.0f,  0.6f, 0.0f);
+				glVertex3f( -0.2f, -0.3f, 0.0f);
+				glVertex3f(  0.2f, -0.3f ,0.0f);
+			}
+			glEnd();
+			
+			//[openGLContext flushBuffer];
+			((void (*)(id, SEL))objc_msgSend)(openGLContext, flushBufferSel);
+		}
+		
+		printf("gracefully terminated\n");
+		
 #ifdef ARC_AVAILABLE
-    }
+	}
 #else
-    //[pool drain];
-    ((void (*)(id, SEL))objc_msgSend)(pool, sel_registerName("drain"));
+	//[pool drain];
+	((void (*)(id, SEL))objc_msgSend)(pool, sel_registerName("drain"));
 #endif
-    return 0;
+	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -93,14 +93,22 @@ void windowWillClose(id self, SEL _sel, id notification)
 
 int main()
 {
+    SEL allocSel = sel_registerName("alloc");
+    SEL initSel = sel_registerName("init");
+    SEL autoreleaseSel = sel_registerName("autorelease");
+    Class NSStringClass = objc_getClass("NSString");
+    SEL stringWithUTF8StringSel = sel_registerName("stringWithUTF8String:");
+    SEL setDelegateSel = sel_registerName("setDelegate:");
+    SEL addItemSel = sel_registerName("addItem:");
+
 	#ifdef ARC_AVAILABLE
 	@autoreleasepool
 	{
 	#else
 	//NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 	//would be nice to use objc_autoreleasePoolPush instead, but it's not publically available in the headers
-	id poolAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSAutoreleasePool"), sel_registerName("alloc"));
-	id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, sel_registerName("init"));
+	id poolAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSAutoreleasePool"), allocSel);
+	id pool = ((id (*)(id, SEL))objc_msgSend)(poolAlloc, initSel);
 	#endif
 	
 	//[NSApplication sharedApplication];
@@ -115,44 +123,44 @@ int main()
 	assert(resultAddProtoc);
 	bool resultAddMethod = class_addMethod(appDelegateClass, sel_registerName("applicationShouldTerminate:"), (IMP)applicationShouldTerminate, NSUIntegerEncoding "@:@");
 	assert(resultAddMethod);
-	id dgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)appDelegateClass, sel_registerName("alloc"));
-	id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, sel_registerName("init"));
+	id dgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)appDelegateClass, allocSel);
+	id dg = ((id (*)(id, SEL))objc_msgSend)(dgAlloc, initSel);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(dg, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(dg, autoreleaseSel);
 	#endif
 	
 	//[NSApp setDelegate:dg];
-	((void (*)(id, SEL, id))objc_msgSend)(NSApp, sel_registerName("setDelegate:"), dg);
+	((void (*)(id, SEL, id))objc_msgSend)(NSApp, setDelegateSel, dg);
 	
 	// only needed if we don't use [NSApp run]
 	//[NSApp finishLaunching];
 	((void (*)(id, SEL))objc_msgSend)(NSApp, sel_registerName("finishLaunching"));
 	
 	//id menubar = [[NSMenu alloc] init];
-	id menubarAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), sel_registerName("alloc"));
-	id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, sel_registerName("init"));
+	id menubarAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), allocSel);
+	id menubar = ((id (*)(id, SEL))objc_msgSend)(menubarAlloc, initSel);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(menubar, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(menubar, autoreleaseSel);
 	#endif
 
 	//id appMenuItem = [[NSMenuItem alloc] init];
-	id appMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
-	id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, sel_registerName("init"));
+	id appMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), allocSel);
+	id appMenuItem = ((id (*)(id, SEL))objc_msgSend)(appMenuItemAlloc, initSel);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(appMenuItem, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(appMenuItem, autoreleaseSel);
 	#endif
 
 	//[menubar addItem:appMenuItem];
-	((void (*)(id, SEL, id))objc_msgSend)(menubar, sel_registerName("addItem:"), appMenuItem);
+	((void (*)(id, SEL, id))objc_msgSend)(menubar, addItemSel, appMenuItem);
 	
 	//[NSApp setMainMenu:menubar];
 	((id (*)(id, SEL, id))objc_msgSend)(NSApp, sel_registerName("setMainMenu:"), menubar);
 	
 	//id appMenu = [[NSMenu alloc] init];
-	id appMenuAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), sel_registerName("alloc"));
-	id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, sel_registerName("init"));
+	id appMenuAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenu"), allocSel);
+	id appMenu = ((id (*)(id, SEL))objc_msgSend)(appMenuAlloc, initSel);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(appMenu, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(appMenu, autoreleaseSel);
 	#endif
 	
 	//id appName = [[NSProcessInfo processInfo] processName];
@@ -160,29 +168,29 @@ int main()
 	id appName = ((id (*)(id, SEL))objc_msgSend)(processInfo, sel_registerName("processName"));
 	
 	//id quitTitle = [@"Quit " stringByAppendingString:appName];
-	id quitTitlePrefixString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), "Quit ");
+	id quitTitlePrefixString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "Quit ");
 	id quitTitle = ((id (*)(id, SEL, id))objc_msgSend)(quitTitlePrefixString, sel_registerName("stringByAppendingString:"), appName);
 	
 	//id quitMenuItem = [[NSMenuItem alloc] initWithTitle:quitTitle action:@selector(terminate:) keyEquivalent:@"q"];
-	id quitMenuItemKey = ((id (*)(id, SEL, const char*))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), "q");
-	id quitMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
+	id quitMenuItemKey = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "q");
+	id quitMenuItemAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSMenuItem"), allocSel);
 	id quitMenuItem = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(quitMenuItemAlloc, sel_registerName("initWithTitle:action:keyEquivalent:"), quitTitle, sel_registerName("terminate:"), quitMenuItemKey);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(quitMenuItem, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(quitMenuItem, autoreleaseSel);
 	#endif
 
 	//[appMenu addItem:quitMenuItem];
-	((void (*)(id, SEL, id))objc_msgSend)(appMenu, sel_registerName("addItem:"), quitMenuItem);
+	((void (*)(id, SEL, id))objc_msgSend)(appMenu, addItemSel, quitMenuItem);
 	
 	//[appMenuItem setSubmenu:appMenu];
 	((void (*)(id, SEL, id))objc_msgSend)(appMenuItem, sel_registerName("setSubmenu:"), appMenu);
 	
 	//id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 500) styleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:NO];
 	NSRect rect = {{0, 0}, {500, 500}};
-	id windowAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSWindow"), sel_registerName("alloc"));
+	id windowAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSWindow"), allocSel);
 	id window = ((id (*)(id, SEL, NSRect, NSUInteger, NSUInteger, BOOL))objc_msgSend)(windowAlloc, sel_registerName("initWithContentRect:styleMask:backing:defer:"), rect, 15, 2, NO);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(window, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(window, autoreleaseSel);
 	#endif
 	
 	// when we are not using ARC, than window will be added to autorelease pool
@@ -199,14 +207,14 @@ int main()
 	assert(resultAddProtoc);
 	resultAddMethod = class_addMethod(WindowDelegateClass, sel_registerName("windowWillClose:"), (IMP)windowWillClose,  "v@:@");
 	assert(resultAddMethod);
-	id wdgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)WindowDelegateClass, sel_registerName("alloc"));
-	id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, sel_registerName("init"));
+	id wdgAlloc = ((id (*)(id, SEL))objc_msgSend)((id)WindowDelegateClass, allocSel);
+	id wdg = ((id (*)(id, SEL))objc_msgSend)(wdgAlloc, initSel);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(wdg, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(wdg, autoreleaseSel);
 	#endif
 
 	//[window setDelegate:wdg];
-	((void (*)(id, SEL, id))objc_msgSend)(window, sel_registerName("setDelegate:"), wdg);
+	((void (*)(id, SEL, id))objc_msgSend)(window, setDelegateSel, wdg);
 	
 	//NSView * contentView = [window contentView];
 	id contentView = ((id (*)(id, SEL))objc_msgSend)(window, sel_registerName("contentView"));
@@ -220,7 +228,7 @@ int main()
 	((void (*)(id, SEL, NSPoint))objc_msgSend)(window, sel_registerName("cascadeTopLeftFromPoint:"), point);
 	
 	//[window setTitle:@"sup"];
-	id titleString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), "sup from C");
+	id titleString = ((id (*)(id, SEL, const char*))objc_msgSend)((id)NSStringClass, stringWithUTF8StringSel, "sup from C");
 	((void (*)(id, SEL, id))objc_msgSend)(window, sel_registerName("setTitle:"), titleString);
 	
 	//NSOpenGLPixelFormatAttribute glAttributes[] =
@@ -249,17 +257,17 @@ int main()
 	};
 	
 	//NSOpenGLPixelFormat * pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:glAttributes];
-	id pixelFormatAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLPixelFormat"), sel_registerName("alloc"));
+	id pixelFormatAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLPixelFormat"), allocSel);
 	id pixelFormat = ((id (*)(id, SEL, const uint32_t*))objc_msgSend)(pixelFormatAlloc, sel_registerName("initWithAttributes:"), glAttributes);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(pixelFormat, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(pixelFormat, autoreleaseSel);
 	#endif
 
 	//NSOpenGLContext * openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
-	id openGLContextAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLContext"), sel_registerName("alloc"));
+	id openGLContextAlloc = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSOpenGLContext"), allocSel);
 	id openGLContext = ((id (*)(id, SEL, id, id))objc_msgSend)(openGLContextAlloc, sel_registerName("initWithFormat:shareContext:"), pixelFormat, nil);
 	#ifndef ARC_AVAILABLE
-	((void (*)(id, SEL))objc_msgSend)(openGLContext, sel_registerName("autorelease"));
+	((void (*)(id, SEL))objc_msgSend)(openGLContext, autoreleaseSel);
 	#endif
 	
 	//[openGLContext setView:contentView];
@@ -284,13 +292,23 @@ int main()
 	while(!terminated)
 	{
 		//NSEvent * event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
-		id distantPast = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSDate"), sel_registerName("distantPast"));
-		id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"), NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
+		static Class NSDateClass = objc_getClass("NSDate");
+		static SEL distantPastSel = sel_registerName("distantPast");
+		id distantPast = ((id (*)(id, SEL))objc_msgSend)((id)NSDateClass, distantPastSel);
+		
+		static SEL nextEventMatchingMaskSel = sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:");
+		id event = ((id (*)(id, SEL, NSUInteger, id, id, BOOL))objc_msgSend)(NSApp, nextEventMatchingMaskSel, NSUIntegerMax, distantPast, NSDefaultRunLoopMode, YES);
+		
+		static SEL frameSel = sel_registerName("frame");
 		
 		if(event)
 		{
 			//NSEventType eventType = [event type];
-			NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, sel_registerName("type"));
+			static SEL typeSel = sel_registerName("type");
+			NSUInteger eventType = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, typeSel);
+			
+			static SEL buttonNumberSel = sel_registerName("buttonNumber");
+			static SEL keyCodeSel = sel_registerName("keyCode");
 			
 			switch(eventType)
 			{
@@ -304,15 +322,18 @@ int main()
 			case 27:
 			{
 				//NSWindow * currentWindow = [NSApp keyWindow];
-				id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, sel_registerName("keyWindow"));
+				static SEL keyWindowSel = sel_registerName("keyWindow");
+				id currentWindow = ((id (*)(id, SEL))objc_msgSend)(NSApp, keyWindowSel);
 
 				//NSRect adjustFrame = [[currentWindow contentView] frame];
-				id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, sel_registerName("contentView"));
-				NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, sel_registerName("frame"));
+				static SEL contentViewSel = sel_registerName("contentView");
+				id currentWindowContentView = ((id (*)(id, SEL))objc_msgSend)(currentWindow, contentViewSel);
+				NSRect adjustFrame = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(currentWindowContentView, frameSel);
 				
 				//NSPoint p = [currentWindow mouseLocationOutsideOfEventStream];
 				// NSPoint is small enough to fit a register, so no need for objc_msgSend_stret
-				NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, sel_registerName("mouseLocationOutsideOfEventStream"));
+				static SEL mouseLocationOutsideOfEventStreamSel = sel_registerName("mouseLocationOutsideOfEventStream");
+				NSPoint p = ((NSPoint (*)(id, SEL))objc_msgSend)(currentWindow, mouseLocationOutsideOfEventStreamSel);
 				
 				// map input to content view rect
 				if(p.x < 0) p.x = 0;
@@ -323,7 +344,8 @@ int main()
 				// map input to pixels
 				NSRect r = {p.x, p.y, 0, 0};
 				//r = [currentWindowContentView convertRectToBacking:r];
-				r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, sel_registerName("convertRectToBacking:"), r);
+				static SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
+				r = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(currentWindowContentView, convertRectToBackingSel, r);
 				p = r.origin;
 				
 				printf("mouse moved to %f %f\n", p.x, p.y);
@@ -351,7 +373,7 @@ int main()
 				// number == 2 is a middle button
 
 				//NSInteger number = [event buttonNumber];
-				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, sel_registerName("buttonNumber"));
+				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
 				printf("mouse other key down : %i\n", (int)number);
 				break;
 			}
@@ -359,7 +381,7 @@ int main()
 			case 26:
 			{
 				//NSInteger number = [event buttonNumber];
-				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, sel_registerName("buttonNumber"));
+				NSInteger number = ((NSInteger (*)(id, SEL))objc_msgSend)(event, buttonNumberSel);
 				printf("mouse other key up : %i\n", (int)number);
 				break;
 			}
@@ -367,13 +389,16 @@ int main()
 			case 22:
 			{
 				//CGFloat deltaX = [event scrollingDeltaX];
-				CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, sel_registerName("scrollingDeltaX"));
+				static SEL scrollingDeltaXSel = sel_registerName("scrollingDeltaX");
+				CGFloat deltaX = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaXSel);
 
 				//CGFloat deltaY = [event scrollingDeltaY];
-				CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, sel_registerName("scrollingDeltaY"));
+				static SEL scrollingDeltaYSel = sel_registerName("scrollingDeltaY");
+				CGFloat deltaY = ((CGFloat (*)(id, SEL))abi_objc_msgSend_fpret)(event, scrollingDeltaYSel);
 				
 				//BOOL precisionScrolling = [event hasPreciseScrollingDeltas];
-				BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, sel_registerName("hasPreciseScrollingDeltas"));
+				static SEL hasPreciseScrollingDeltasSel = sel_registerName("hasPreciseScrollingDeltas");
+				BOOL precisionScrolling = ((BOOL (*)(id, SEL))objc_msgSend)(event, hasPreciseScrollingDeltasSel);
 
 				if(precisionScrolling)
 				{
@@ -389,7 +414,8 @@ int main()
 			case 12:
 			{
 				//NSEventModifierFlags modifiers = [event modifierFlags];
-				NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, sel_registerName("modifierFlags"));
+				static SEL modifierFlagsSel = sel_registerName("modifierFlags");
+				NSUInteger modifiers = ((NSUInteger (*)(id, SEL))objc_msgSend)(event, modifierFlagsSel);
 				
 				// based on NSEventModifierFlags
 				struct
@@ -421,14 +447,16 @@ int main()
 			case 10:
 			{
 				//NSString * inputText = [event characters];
-				id inputText = ((id (*)(id, SEL))objc_msgSend)(event, sel_registerName("characters"));
+				static SEL charactersSel = sel_registerName("characters");
+				id inputText = ((id (*)(id, SEL))objc_msgSend)(event, charactersSel);
 				
 				//const char * inputTextUTF8 = [inputText UTF8String];
-				const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, sel_registerName("UTF8String"));
+				static SEL UTF8StringSel = sel_registerName("UTF8String");
+				const char * inputTextUTF8 = ((const char* (*)(id, SEL))objc_msgSend)(inputText, UTF8StringSel);
 				
 				//you can get list of virtual key codes from Carbon HIToolbox/Events.h
 				//uint16_t keyCode = [event keyCode];
-				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, sel_registerName("keyCode"));
+				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
 
 				printf("key down %u, text '%s'\n", keyCode, inputTextUTF8);
 				break;
@@ -437,7 +465,7 @@ int main()
 			case 11:
 			{
 				//uint16_t keyCode = [event keyCode];
-				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, sel_registerName("keyCode"));
+				uint16_t keyCode = ((unsigned short (*)(id, SEL))objc_msgSend)(event, keyCodeSel);
 				
 				printf("key up %u\n", keyCode);
 				break;
@@ -447,28 +475,33 @@ int main()
 			}
 			
 			//[NSApp sendEvent:event];
-			((void (*)(id, SEL, id))objc_msgSend)(NSApp, sel_registerName("sendEvent:"), event);
+			static SEL sendEventSel = sel_registerName("sendEvent");
+			((void (*)(id, SEL, id))objc_msgSend)(NSApp, sendEventSel, event);
 			
 			// if user closes the window we might need to terminate asap
 			if(terminated)
 				break;
 			
 			//[NSApp updateWindows];
-			((void (*)(id, SEL))objc_msgSend)(NSApp, sel_registerName("updateWindows"));
+			static SEL updateWindowsSel = sel_registerName("updateWindows");
+			((void (*)(id, SEL))objc_msgSend)(NSApp, updateWindowsSel);
 		}
 		
 		// do runloop stuff
 		//[openGLContext update]; // probably we only need to do it when we resize the window
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, sel_registerName("update"));
+		static SEL updateSel = sel_registerName("update");
+		((void (*)(id, SEL))objc_msgSend)(openGLContext, updateSel);
 		
 		//[openGLContext makeCurrentContext];
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, sel_registerName("makeCurrentContext"));
+		static SEL makeCurrentContextSel = sel_registerName("makeCurrentContext");
+		((void (*)(id, SEL))objc_msgSend)(openGLContext, makeCurrentContextSel);
 		
 		//NSRect rect = [contentView frame];
-		NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, sel_registerName("frame"));
+		NSRect rect = ((NSRect (*)(id, SEL))abi_objc_msgSend_stret)(contentView, frameSel);
 		
 		//rect = [contentView convertRectToBacking:rect];
-		rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, sel_registerName("convertRectToBacking:"), rect);
+		static SEL convertRectToBackingSel = sel_registerName("convertRectToBacking:");
+		rect = ((NSRect (*)(id, SEL, NSRect))abi_objc_msgSend_stret)(contentView, convertRectToBackingSel, rect);
 		
 		glViewport(0, 0, rect.size.width, rect.size.height);
 		
@@ -484,7 +517,8 @@ int main()
 		glEnd();
 		
 		//[openGLContext flushBuffer];
-		((void (*)(id, SEL))objc_msgSend)(openGLContext, sel_registerName("flushBuffer"));
+		static SEL flushBufferSel = sel_registerName("flushBuffer");
+		((void (*)(id, SEL))objc_msgSend)(openGLContext, flushBufferSel);
 	}
 		
 	printf("gracefully terminated\n");


### PR DESCRIPTION
Looking up SEL and Class pointers every time they are needed is not efficient, because Objective-C runtime has to look up the cache every time. So I store pointers to classes and SELs that are used multiple times for later use.
